### PR TITLE
Remove unnecessary return value

### DIFF
--- a/extensions/ambassadors/campaign-submission-form/automatically-set-donation-options.php
+++ b/extensions/ambassadors/campaign-submission-form/automatically-set-donation-options.php
@@ -41,7 +41,6 @@ function en_set_suggested_donations( $submitted, $campaign_id ) {
     // Also set the custom donations to be permitted.
     update_post_meta( $campaign_id, '_campaign_allow_custom_donations', 1 );
 
-    return $meta;
 }
 
 add_action( 'charitable_campaign_submission_save', 'en_set_suggested_donations', 10, 2 );


### PR DESCRIPTION
the `$meta` value is undefined and triggers a notice. Also triggers a warning: `Warning: Cannot modify header information - headers already sent by (output started at /Applications/MAMP/htdocs/wordpress/wp-content/plugins/pgi-charitable/pgi-charitable.php:66) in /Applications/MAMP/htdocs/wordpress/wp-includes/pluggable.php on line 1167`