### PR TITLE
Update add-read-more-link.php

### DIFF
--- a/campaign-loop/add-read-more-link.php
+++ b/campaign-loop/add-read-more-link.php
@@ -15,7 +15,7 @@
  * @return  void
  */
 function ed_add_read_more_link_to_campaigns( $campaign ) {
-	printf( __( '<a href="%s">Read More</a>', 'your-namespace' ), get_permalink( $campaign ) );
+	printf( __( '<a href="%s">Read More</a>', 'your-namespace' ), get_permalink( $campaign->ID ) );
 }
 
 add_action( 'charitable_campaign_content_loop_after', 'ed_add_read_more_link_to_campaigns', 5 );


### PR DESCRIPTION
$campaign is a post object and the get_permalink function apparently needs the ID